### PR TITLE
添加EPOLLRDHUP处理

### DIFF
--- a/cpp/src/base/EventDispatch.cpp
+++ b/cpp/src/base/EventDispatch.cpp
@@ -329,7 +329,15 @@ void CEventDispatch::StartDispatch()
 			CBaseSocket* pSocket = FindBaseSocket(ev_fd);
 			if (!pSocket)
 				continue;
-
+		
+                #ifdef EPOLLRDHUP
+                        if (events[i].events & EPOLLRDHUP)
+                        {
+                        	//log("On Peer Close, socket=%d, ev_fd);
+                        	pSocket->OnRead();
+                        }
+                #endif
+                
 			if (events[i].events & EPOLLIN)
 			{
 				//log("OnRead, socket=%d\n", ev_fd);


### PR DESCRIPTION
http://stackoverflow.com/questions/8707458/epoll-and-remote-1-way-shutdown
低版本内核未定义EPOLLRDHUP
client端正常主动关闭时，epoll会同时收到EPOLLRDHUP和EPOLLIN。曾经在狼厂追查过由该问题引起产生额外读数据失败日志问题。